### PR TITLE
Add patch to set version from git tag instead of git hash

### DIFF
--- a/depends/common/gearcoleco/0001-Use-latest-git-tag-instead-of-git-hash.patch
+++ b/depends/common/gearcoleco/0001-Use-latest-git-tag-instead-of-git-hash.patch
@@ -1,0 +1,32 @@
+From 5ea6225aa4497fd68a3894b941fb439e2c138cbe Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Sun, 1 Sep 2024 16:55:47 -0700
+Subject: [PATCH] Use latest git tag instead of git hash
+
+We force GIT_VERSION to "" in the CMakeLists.txt file.
+---
+ platforms/libretro/Makefile | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/platforms/libretro/Makefile b/platforms/libretro/Makefile
+index 01db018..61da7e6 100644
+--- a/platforms/libretro/Makefile
++++ b/platforms/libretro/Makefile
+@@ -325,6 +325,14 @@ endif
+ GIT_VERSION ?= " $(shell git describe --abbrev=7 --dirty --always --tags || echo unknown)"
+ ifneq ($(GIT_VERSION)," unknown")
+    CXXFLAGS += -DEMULATOR_BUILD=\"$(GIT_VERSION)\"
++   CXXFLAGS += -DEMULATOR_BUILD=\"$(shell \
++      if git rev-parse --is-shallow-repository > /dev/null 2>&1; then \
++         git fetch --unshallow --tags origin main > /dev/null 2>&1; \
++      else \
++         git fetch --tags origin main > /dev/null 2>&1; \
++      fi; \
++      git describe --tags --abbrev=0 --always \
++   )\"
+ endif
+ 
+ include Makefile.common
+-- 
+2.34.1
+


### PR DESCRIPTION
## Description

Currently, the version for Gearcoleco is set via git hash, but we override this and set it to the empty string. So as a result, the version "`unknown`" is used (defined in the source when `EMULATOR_BUILD` is empty).

Instead, obtain the version from the latest tag in the `main` branch (see tags here: https://github.com/drhelius/Gearcoleco/tags)

Complicated shell command is because CI fetches shallow, and we need the entire history to search for the latest tag.

## How has this been tested?

Before ([log](https://paste.kodi.tv/kiranesego.kodi)):

```
info <general>: AddOnLog: game.libretro.gearcoleco: Gearcoleco (undefined) libretro
```

After:

Version is set correctly via CI: https://github.com/kodi-game/game.libretro.gearcoleco/commit/fac7d0b38114a1041cd20b7bf265d61218fedbc3

```patch
diff --git a/debian/control b/debian/control
index c747952..8e10a56 100644
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Maintainer: wsnipex <wsnipex@a1.net>
 Build-Depends: debhelper (>= 9.0.0),
                cmake,
                kodi-addon-dev,
-               libretro-gearcoleco (>= 0.0.1) | gearcoleco (>= 0.0.1)
+               libretro-gearcoleco (>= 1.2.0) | gearcoleco (>= 1.2.0)
 Standards-Version: 3.9.8
 Section: libs
 
diff --git a/game.libretro.gearcoleco/addon.xml.in b/game.libretro.gearcoleco/addon.xml.in
index 539705b..6cc8ecb 100644
--- a/game.libretro.gearcoleco/addon.xml.in
+++ b/game.libretro.gearcoleco/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="game.libretro.gearcoleco"
 		name="Coleco - ColecoVision (Gearcoleco)"
-		version="0.0.1.16"
+		version="1.2.0.17"
 		provider-name="Ignacio Sanchez">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
```