### PR TITLE
Add version updater script and patch

### DIFF
--- a/depends/common/gearcoleco/0001-Explicitly-set-version-variable.patch
+++ b/depends/common/gearcoleco/0001-Explicitly-set-version-variable.patch
@@ -1,0 +1,25 @@
+From 3a63b6d9f2df915666a78b7ab80bf1f5861f203e Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Sun, 1 Sep 2024 16:55:47 -0700
+Subject: [PATCH] Explicitly set version variable
+
+---
+ platforms/libretro/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/platforms/libretro/Makefile b/platforms/libretro/Makefile
+index 01db018..a5c9298 100644
+--- a/platforms/libretro/Makefile
++++ b/platforms/libretro/Makefile
+@@ -324,7 +324,7 @@ endif
+ 
+ GIT_VERSION ?= " $(shell git describe --abbrev=7 --dirty --always --tags || echo unknown)"
+ ifneq ($(GIT_VERSION)," unknown")
+-   CXXFLAGS += -DEMULATOR_BUILD=\"$(GIT_VERSION)\"
++   CXXFLAGS += -DEMULATOR_BUILD=\"1.2.0\"
+ endif
+ 
+ include Makefile.common
+-- 
+2.37.0.windows.1
+

--- a/update-version.sh
+++ b/update-version.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+################################################################################
+# Copyright (C) 2024 Team Kodi
+# SPDX-License-Identifier: GPL-2.0-or-later
+################################################################################
+
+#
+# Script to update the EMULATOR_BUILD version in a patch file based on the
+# latest Git tag from a specified repository.
+#
+# The script:
+#
+#   - Reads the repository URL and commit hash from a configuration file
+#   - Clones the repository
+#   - Determines the latest tag leading up to the specified commit
+#   - Updates the patch file with the new version
+#
+# Run this script and commit the result when new versions are tagged upstream.
+#
+
+# Load the gearcoleco.txt file
+FILE_PATH="./depends/common/gearcoleco/gearcoleco.txt"
+
+if [[ ! -f "${FILE_PATH}" ]]; then
+  echo "File not found: ${FILE_PATH}"
+  exit 1
+fi
+
+# Extract the base URL and the hash from the file
+REPO_URL=$(awk '{print $2}' "${FILE_PATH}" | sed 's/\/archive\/.*//')
+COMMIT_HASH=$(awk -F '/' '{print $NF}' "${FILE_PATH}" | sed 's/.tar.gz//')
+
+# Clone the repository to a temporary directory
+TMP_DIR=$(mktemp -d)
+
+# Set up a trap to clean up the temporary directory on exit
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+git clone "${REPO_URL}" "${TMP_DIR}"
+
+# Navigate to the cloned repository
+cd "${TMP_DIR}" || exit
+
+# Fetch all tags and history
+git fetch --tags
+
+# Find the latest tag leading up to the commit hash
+LATEST_TAG=$(git describe --tags --abbrev=0 "${COMMIT_HASH}")
+
+if [[ -z "${LATEST_TAG}" ]]; then
+  echo "No tag found leading up to the commit hash: ${COMMIT_HASH}"
+  exit 1
+fi
+
+echo "Latest tag leading up to ${COMMIT_HASH} is ${LATEST_TAG}"
+
+# Navigate back to the original repository
+cd - || exit
+
+# Update the patch file with the latest tag
+PATCH_FILE="./depends/common/gearcoleco/0001-Explicitly-set-version-variable.patch"
+sed -i "s/+   CXXFLAGS += -DEMULATOR_BUILD=.*/+   CXXFLAGS += -DEMULATOR_BUILD=\\\\\"${LATEST_TAG}\\\\\"/" "${PATCH_FILE}"
+
+echo "Updated ${PATCH_FILE} with EMULATOR_BUILD=${LATEST_TAG}"


### PR DESCRIPTION
## Description

This is an alternative to https://github.com/kodi-game/game.libretro.gearcoleco/pull/1.

The patch didn't work on Jenkins CI because Jenkins checks out the code with a tar.gz, no git repo to query tags against.

So here, we hardcode the version number in the patch, and provide a shell script that updates the version, where it can then be committed.

The gearcoleco dependency should be updated and the `update-version.sh` script run when a new version of Gearcoleco is tagged.

## How has this been tested?

Before, with #1 the Kodi version would be used when building on Jenkins CI which uses tar.gz:

```
 info <general>: AddOnLog: game.libretro.gearcoleco: Gearcoleco (21.1-Omega) libretro
debug <general>: AddOnLog: game.libretro.gearcoleco: CORE: ----------------------------------
debug <general>: AddOnLog: game.libretro.gearcoleco: CORE: Library name:    Gearcoleco
debug <general>: AddOnLog: game.libretro.gearcoleco: CORE: Library version: 21.1-Omega
debug <general>: AddOnLog: game.libretro.gearcoleco: CORE: Extensions:      col|cv|bin|rom
debug <general>: AddOnLog: game.libretro.gearcoleco: CORE: Supports VFS:    true
debug <general>: AddOnLog: game.libretro.gearcoleco: CORE: ----------------------------------
```

After:

```
 info <general>: AddOnLog: game.libretro.gearcoleco: Gearcoleco (1.2.0) libretro
debug <general>: AddOnLog: game.libretro.gearcoleco: CORE: ----------------------------------
debug <general>: AddOnLog: game.libretro.gearcoleco: CORE: Library name:    Gearcoleco
debug <general>: AddOnLog: game.libretro.gearcoleco: CORE: Library version: 1.2.0
debug <general>: AddOnLog: game.libretro.gearcoleco: CORE: Extensions:      col|cv|bin|rom
debug <general>: AddOnLog: game.libretro.gearcoleco: CORE: Supports VFS:    true
debug <general>: AddOnLog: game.libretro.gearcoleco: CORE: ----------------------------------
```